### PR TITLE
fix blog template layouts

### DIFF
--- a/themes/smi/layouts/blog/list.html
+++ b/themes/smi/layouts/blog/list.html
@@ -1,4 +1,4 @@
-{{ partial "header.html" . }}
+{{ define "main" }}
 
 <div class="blog blog-wrapper height-full">
   <div class="row row-full">
@@ -69,5 +69,4 @@
     };
   }
 </script>
-
-{{ partial "footer.html" . }}
+{{ end }}

--- a/themes/smi/layouts/blog/single.html
+++ b/themes/smi/layouts/blog/single.html
@@ -1,4 +1,4 @@
-{{ partial "header.html" . }}
+{{ define "main" }}
 
 <div class="blog blog-wrapper blog-single height-full">
   <div class="row row-full">
@@ -33,4 +33,4 @@
   }
 </script>
 
-{{ partial "footer.html" . }}
+{{ end }}


### PR DESCRIPTION
Investigating the draft blog post in #30, the `/blog` layout was borked and failing to render any `<head>` info, style imports, etc. This PR adjusts the templates to render properly once again. 

Signed-off-by: flynnduism <dev@ronan.design>