### PR TITLE
Removing Luc as he's changing roles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lachie83 @bridgetkromhout @flynnduism @lucperkins
+* @lachie83 @bridgetkromhout @flynnduism


### PR DESCRIPTION
Goodbye and thanks to @lucperkins as he changes roles!

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>