### PR TITLE
Use right logo for Istio

### DIFF
--- a/data/logos.yaml
+++ b/data/logos.yaml
@@ -24,8 +24,8 @@ ecosystem:
   url: https://solo.io/products/service-mesh-hub
   logo: logo-service-mesh-hub.png
 - title: Istio
-  logo: istio-text.png
-  url: https://github.com/deislabs/smi-adapter-istio
+  logo: logo-istio.png
+  url: https://istio.io/
 partners:
 - title: Microsoft
   url: https://microsoft.com


### PR DESCRIPTION
Ref: https://smi-spec.io/#ecosystem

The logo is already available in `themes/smi/static/img/logos/`

Before:

![istio-logo-old](https://user-images.githubusercontent.com/2920003/94773512-8b9c6080-03d9-11eb-84c0-1bfd30ee3660.png)

After

![istio-logo](https://user-images.githubusercontent.com/2920003/94773580-b090d380-03d9-11eb-82f6-c0c43a2136d3.png)
